### PR TITLE
Update CI to use build_type from matrix

### DIFF
--- a/.github/workflows/cmake-clang.yml
+++ b/.github/workflows/cmake-clang.yml
@@ -7,8 +7,8 @@ on:
     branches: [ "main" ]
 
 env:
-  CXX_COMPILER: clang++-17
-  C_COMPILER: clang-17
+  CXX_COMPILER: clang++-20
+  C_COMPILER: clang-20
 
 jobs:
   build:
@@ -27,9 +27,9 @@ jobs:
     - name: Prepare environment
       run: |
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && \
-        sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main' && \
+        sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main' && \
         sudo apt update && \
-        sudo apt-get install clang-17 lldb-17 lld-17 libc++-17-dev libc++abi-17-dev
+        sudo apt-get install clang-20 lldb-20 lld-20 libc++-20-dev libc++abi-20-dev
 
     - name: Configure CMake
       run: cmake -B ${{env.BUILD_DIR}} -DCMAKE_CXX_COMPILER=${{env.CXX_COMPILER}} -DCMAKE_C_COMPILER=${{env.C_COMPILER}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}}

--- a/.github/workflows/cmake-clang.yml
+++ b/.github/workflows/cmake-clang.yml
@@ -26,10 +26,8 @@ jobs:
 
     - name: Prepare environment
       run: |
-        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && \
-        sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main' && \
-        sudo apt update && \
-        sudo apt-get install clang-20 lldb-20 lld-20 libc++-20-dev libc++abi-20-dev
+        sudo apt-get update
+        sudo apt-get install -y clang-20 lld-20 libc++-20-dev libc++abi-20-dev
 
     - name: Configure CMake
       run: cmake -B ${{env.BUILD_DIR}} -DCMAKE_CXX_COMPILER=${{env.CXX_COMPILER}} -DCMAKE_C_COMPILER=${{env.C_COMPILER}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}}

--- a/.github/workflows/cmake-clang.yml
+++ b/.github/workflows/cmake-clang.yml
@@ -39,4 +39,4 @@ jobs:
 
     - name: Test
       working-directory: ${{env.BUILD_DIR}}
-      run: ctest -C ${{env.BUILD_TYPE}}
+      run: ctest -C ${{matrix.build_type}}

--- a/.github/workflows/cmake-gcc.yml
+++ b/.github/workflows/cmake-gcc.yml
@@ -53,3 +53,4 @@ jobs:
         fail_ci_if_error: true
         verbose: true
         files: coverage.info
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/cmake-gcc.yml
+++ b/.github/workflows/cmake-gcc.yml
@@ -7,8 +7,8 @@ on:
     branches: [ "main" ]
 
 env:
-  CXX_COMPILER: g++-12
-  C_COMPILER: gcc-12
+  CXX_COMPILER: g++-14
+  C_COMPILER: gcc-14
 
 jobs:
   build:
@@ -39,8 +39,8 @@ jobs:
       working-directory: ${{github.workspace}}
       run: |
         sudo apt-get install lcov
-        lcov --gcov-tool gcov-12 --base-directory . --directory ${{env.BUILD_DIR}} -c -o coverage.info
-        lcov --gcov-tool gcov-12 --remove coverage.info "test/*" -o coverage.info
+        lcov --gcov-tool gcov-14 --base-directory . --directory ${{env.BUILD_DIR}} -c -o coverage.info
+        lcov --gcov-tool gcov-14 --remove coverage.info "test/*" -o coverage.info
 
     - name: Upload coverage to Codecov
       if: ${{matrix.build_type == 'Debug'}}

--- a/.github/workflows/cmake-gcc.yml
+++ b/.github/workflows/cmake-gcc.yml
@@ -38,9 +38,13 @@ jobs:
       if: ${{matrix.build_type == 'Debug'}}
       working-directory: ${{github.workspace}}
       run: |
-        sudo apt-get install lcov
-        lcov --gcov-tool gcov-14 --base-directory . --directory ${{env.BUILD_DIR}} -c -o coverage.info
-        lcov --gcov-tool gcov-14 --remove coverage.info "test/*" -o coverage.info
+        set -eux
+        python3 -m pip install --upgrade pip
+        python3 -m pip install gcovr
+        g++-14 --version
+        gcov-14 --version
+        gcovr --version
+        gcovr -r . --gcov-executable gcov-14 --object-directory ${{env.BUILD_DIR}} --exclude 'test/.*' --exclude '3p/.*' --lcov -o coverage.info
 
     - name: Upload coverage to Codecov
       if: ${{matrix.build_type == 'Debug'}}

--- a/.github/workflows/cmake-gcc.yml
+++ b/.github/workflows/cmake-gcc.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Test
       working-directory: ${{env.BUILD_DIR}}
-      run: ctest -C ${{env.BUILD_TYPE}}
+      run: ctest -C ${{matrix.build_type}}
 
     - name: Generate coverage report
       if: ${{matrix.build_type == 'Debug'}}


### PR DESCRIPTION
Upgrade/fixes for CI and toolchain.
 
- In gcc and clang CI workflows, ctest switched to use matrix.build_type instead of env.BUILD_TYPE
- In gcc workflow:
  - upgraded the gcc compiler environment from v. 12 to v.14
  - replaced lcov coverage collection with gcovr
  - excluded test/.* and 3p/.* paths from coverage output
  - added an explicit Codecov upload token